### PR TITLE
Add hibernate-after-suspend system extension

### DIFF
--- a/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system-preset/00-steamos-extension-hibernate-after-sleep.preset
+++ b/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system-preset/00-steamos-extension-hibernate-after-sleep.preset
@@ -1,0 +1,3 @@
+enable steamos-extension-hibernate-after-sleep-install.service
+enable steamos-extension-hibernate-after-sleep-fix-bluetooth.service
+enable steamos-extension-hibernate-after-sleep-mark-boot-good.service

--- a/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-fix-bluetooth.service
+++ b/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-fix-bluetooth.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Fix Bluetooth After Resume
+After=hibernate.target hybrid-sleep.target suspend-then-hibernate.target bluetooth.service suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/steamos-extension-hibernate-after-sleep-fix-bluetooth
+
+[Install]
+WantedBy=hibernate.target hybrid-sleep.target suspend-then-hibernate.target suspend.target

--- a/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-install.service
+++ b/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-install.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Configure Hibernation After Sleep
+DefaultDependencies=false
+Requires=systemd-sysext.service
+After=systemd-sysext.service
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/steamos-extension-hibernate-after-sleep-install
+
+[Install]
+WantedBy=sysinit.target

--- a/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-mark-boot-good.service
+++ b/steamos-extension-hibernate-after-sleep/usr/lib/systemd/system/steamos-extension-hibernate-after-sleep-mark-boot-good.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Mark Boot State Good After Resume
+After=suspend.target suspend-then-hibernate.target hibernate.target hybrid-sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/steamos-extension-hibernate-after-sleep-mark-boot-good
+
+[Install]
+WantedBy=suspend.target suspend-then-hibernate.target hibernate.target hybrid-sleep.target

--- a/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-fix-bluetooth
+++ b/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-fix-bluetooth
@@ -1,0 +1,21 @@
+#!/bin/bash
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+is_bluetooth_ok() {
+    echo "Checking Bluetooth status..."
+    bluetoothctl discoverable on
+    if [ $? -ne 0 ]; then
+        echo "Bluetooth is misbehaving."
+        return 1  # Bluetooth needs fixing
+    else
+        echo "Bluetooth is working fine."
+        return 0  # Bluetooth is OK
+    fi
+}
+
+sleep 2 # make sure system woke up completely
+
+if ! is_bluetooth_ok; then
+    # if bluetooth problem detected, reinitialize the driver
+	(echo serial0-0 > /sys/bus/serial/drivers/hci_uart_qca/unbind ; sleep 1 && echo serial0-0 > /sys/bus/serial/drivers/hci_uart_qca/bind)
+fi

--- a/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-install
+++ b/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-install
@@ -1,0 +1,268 @@
+#!/bin/bash
+set -e
+
+TargetSwapFileSizeInGbs=20
+HibernateDelaySec="60min"
+FORCE=0
+
+function load_config {
+	local config_file="/home/deck/.config/hibernate-after-sleep"
+	if [[ -f "$config_file" ]]; then
+		local value=$(grep -E '^HibernateDelaySec=' "$config_file" | head -1 | cut -d= -f2 | tr -d '"' | grep -oE '^[0-9]+[a-z]+( [0-9]+[a-z]+)*$')
+		if [[ -n "$value" ]]; then
+			HibernateDelaySec="$value"
+		fi
+
+		value=$(grep -E '^TargetSwapFileSizeInGbs=' "$config_file" | head -1 | cut -d= -f2 | tr -d '"' | grep -oE '^[0-9]+$')
+		if [[ -n "$value" ]]; then
+			TargetSwapFileSizeInGbs="$value"
+		fi
+	fi
+}
+
+function is_btrfs {
+	local fstype=$(findmnt -no FSTYPE -T /home)
+	[[ "$fstype" == "btrfs" ]]
+}
+
+function get_swapfile_path {
+	if is_btrfs; then
+		echo "/home/@swapfile/swapfile"
+	else
+		echo "/home/swapfile"
+	fi
+}
+
+function setup_swapfile_btrfs {
+	local swapfile_path="/home/@swapfile/swapfile"
+	local target_size="${TargetSwapFileSizeInGbs}G"
+
+	if [[ ! -d "/home/@swapfile" ]]; then
+		btrfs subvolume create /home/@swapfile
+	fi
+
+	local needs_rebuild=0
+	if [[ ! -f "$swapfile_path" ]]; then
+		needs_rebuild=1
+	else
+		local target_bytes=$(($TargetSwapFileSizeInGbs*1073741824))
+		local current_size=$(stat -c %s "$swapfile_path" 2>/dev/null || echo 0)
+		if [[ $current_size != $target_bytes ]]; then
+			needs_rebuild=1
+		fi
+	fi
+
+	if [[ $needs_rebuild -eq 1 ]]; then
+		echo "Configuring swapfile on BTRFS"
+		swapoff "$swapfile_path" 2>/dev/null || true
+		rm -f "$swapfile_path"
+		truncate -s 0 "$swapfile_path"
+		chattr +C "$swapfile_path"
+		fallocate -l "$target_size" "$swapfile_path"
+		chmod 600 "$swapfile_path"
+		mkswap "$swapfile_path"
+		swapon "$swapfile_path"
+	fi
+}
+
+function setup_swapfile_ext4 {
+	local swapfile_path="/home/swapfile"
+	local target_bytes=$(($TargetSwapFileSizeInGbs*1073741824))
+	local current_size=$(stat -c %s "$swapfile_path" 2>/dev/null || echo 0)
+
+	if [[ $current_size != $target_bytes ]]; then
+		echo "Configuring swapfile"
+		swapoff -a 2>/dev/null || true
+		dd if=/dev/zero of="$swapfile_path" bs=1G count=$TargetSwapFileSizeInGbs
+		chmod 600 "$swapfile_path"
+		mkswap "$swapfile_path"
+		swapon "$swapfile_path"
+		e4defrag "$swapfile_path" 2>/dev/null || true
+	fi
+}
+
+function setup_swapfile {
+	if is_btrfs; then
+		setup_swapfile_btrfs
+	else
+		setup_swapfile_ext4
+	fi
+}
+
+function get_swap_offset {
+	local swapfile_path=$(get_swapfile_path)
+
+	if is_btrfs; then
+		btrfs inspect-internal map-swapfile -r "$swapfile_path"
+	else
+		filefrag -v "$swapfile_path" | awk '$1=="0:" {print substr($4, 1, length($4)-2)}'
+	fi
+}
+
+function update_grub_resume {
+	local swapfile_path=$(get_swapfile_path)
+	local uuid=$(findmnt -no UUID -T "$swapfile_path")
+	local offset=$(get_swap_offset)
+	local starter=steamenv_boot
+	local cfg=/boot/efi/EFI/steamos/grub.cfg
+	local remount=false
+
+	# HoloISO
+	if [[ -f /boot/grub/grub.cfg ]]; then
+		starter=linux
+		cfg=/boot/grub/grub.cfg
+		remount=true
+	fi
+
+	if [[ ! -e $cfg ]]; then
+		echo "Warning: GRUB config file not found at $cfg"
+		return 1
+	fi
+
+	# Check if resume parameters are already set correctly
+	if grep -q "resume=/dev/disk/by-uuid/$uuid" "$cfg" && grep -q "resume_offset=$offset" "$cfg"; then
+		echo "GRUB resume parameters already configured correctly"
+		return 0
+	fi
+
+	# HoloISO keeps boot on the readonly partition.
+	if $remount && [[ ! -f /tmp/.hibernate-after-sleep-readonly-disabled ]]; then
+		steamos-readonly disable
+		touch /tmp/.hibernate-after-sleep-readonly-disabled
+	fi
+
+	echo "Updating GRUB configuration"
+
+	# Remove existing resume parameters if present
+	sed -i -E 's/ resume=[^ ]*//g' "$cfg"
+	sed -i -E 's/ resume_offset=[0-9]*//g' "$cfg"
+
+	# Add new resume parameters
+	sed -i -E 's@^(\s*)'$starter'(.*)$@\1'$starter'\2 resume=/dev/disk/by-uuid/'$uuid' resume_offset='$offset'@g' "$cfg"
+	touch /tmp/.hibernate-after-sleep-modified
+}
+
+function ensure_logind_bypass {
+	local override_dir="/etc/systemd/system/systemd-logind.service.d"
+	local override_file="$override_dir/override.conf"
+	local env_var="Environment=SYSTEMD_BYPASS_HIBERNATION_MEMORY_CHECK=1"
+	local needs_reload=0
+
+	mkdir -p "$override_dir"
+
+	if [[ ! -f "$override_file" ]]; then
+		echo "[Service]" > "$override_file"
+		echo "$env_var" >> "$override_file"
+        chmod 644 $override_file
+		needs_reload=1
+	else
+		if grep -q "^Environment=SYSTEMD_BYPASS_HIBERNATION_MEMORY_CHECK=1" "$override_file"; then
+			return 0
+		fi
+
+		local in_service_section=0
+		local temp_file=$(mktemp)
+
+		while IFS= read -r line; do
+			if [[ "$line" =~ ^\[Service\] ]]; then
+				in_service_section=1
+				echo "$line" >> "$temp_file"
+			elif [[ "$line" =~ ^\[.*\] ]]; then
+				if [[ $in_service_section -eq 1 ]]; then
+					echo "$env_var" >> "$temp_file"
+					in_service_section=0
+					needs_reload=1
+				fi
+				echo "$line" >> "$temp_file"
+			else
+				echo "$line" >> "$temp_file"
+			fi
+		done < "$override_file"
+
+		if [[ $in_service_section -eq 1 ]]; then
+			echo "$env_var" >> "$temp_file"
+			needs_reload=1
+		fi
+
+		if [[ $needs_reload -eq 0 ]]; then
+			echo "" >> "$temp_file"
+			echo "[Service]" >> "$temp_file"
+			echo "$env_var" >> "$temp_file"
+			needs_reload=1
+		fi
+
+		mv "$temp_file" "$override_file"
+        chmod 644 $override_file
+	fi
+
+	if [[ $needs_reload -eq 1 ]]; then
+		echo "Configuring systemd-logind hibernation bypass"
+		systemctl daemon-reload
+	fi
+}
+
+function enable_suspend_hibernate {
+	local suspend_service="/etc/systemd/system/systemd-suspend.service"
+	local target_service="/usr/lib/systemd/system/systemd-suspend-then-hibernate.service"
+
+	if [[ ! -f "$suspend_service" ]]; then
+		echo "Enabling suspend-then-hibernate"
+		ln -s "$target_service" "$suspend_service"
+		systemctl daemon-reload
+	fi
+}
+
+function update_sleep_config {
+	echo "[Sleep]
+AllowSuspend=yes
+AllowHibernation=yes
+AllowSuspendThenHibernate=yes
+HibernateDelaySec=$HibernateDelaySec" > /etc/systemd/sleep.conf
+	echo "Configured hibernate delay: $HibernateDelaySec"
+}
+
+function enable_resume_services {
+	systemctl enable steamos-extension-hibernate-after-sleep-fix-bluetooth.service 2>/dev/null || true
+	systemctl enable steamos-extension-hibernate-after-sleep-mark-boot-good.service 2>/dev/null || true
+}
+
+function install_uninstall_script {
+	local bin_dir="/home/deck/.bin"
+	local uninstall_source="/usr/share/doc/steamos-extension-hibernate-after-sleep/steamos-extension-hibernate-after-sleep-uninstall.sh"
+	local uninstall_dest="$bin_dir/steamos-extension-hibernate-after-sleep-uninstall.sh"
+
+	mkdir -p "$bin_dir"
+	chown deck:deck "$bin_dir"
+
+	if [[ -f "$uninstall_source" ]]; then
+		cp "$uninstall_source" "$uninstall_dest"
+		chmod 755 "$uninstall_dest"
+		chown root:root "$uninstall_dest"
+	fi
+}
+
+function cleanup {
+	if [[ -f /tmp/.hibernate-after-sleep-readonly-disabled ]]; then
+		rm -f /tmp/.hibernate-after-sleep-readonly-disabled
+		steamos-readonly enable
+	fi
+
+	if [[ -f /tmp/.hibernate-after-sleep-modified ]]; then
+		rm -f /tmp/.hibernate-after-sleep-modified
+		echo "GRUB configuration updated. Please reboot for changes to take effect."
+	fi
+}
+
+if [[ "$1" == "--force" ]]; then
+	FORCE=1
+fi
+
+load_config
+setup_swapfile
+update_grub_resume
+ensure_logind_bypass
+enable_suspend_hibernate
+update_sleep_config
+enable_resume_services
+install_uninstall_script
+cleanup

--- a/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-mark-boot-good
+++ b/steamos-extension-hibernate-after-sleep/usr/sbin/steamos-extension-hibernate-after-sleep-mark-boot-good
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+IMG=$(steamos-bootconf this-image)
+steamos-bootconf --image "$IMG" --set boot-attempts 0

--- a/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/README
+++ b/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/README
@@ -1,0 +1,94 @@
+SteamOS Extension: Hibernate After Sleep
+========================================
+
+This extension enables hibernate-after-sleep functionality on the Steam Deck,
+allowing the device to automatically hibernate after being suspended for a
+configurable period of time.
+
+Features
+--------
+
+- Automatically creates and configures a swap file for hibernation
+- Configures GRUB bootloader with resume parameters
+- Sets up systemd to use suspend-then-hibernate
+- Fixes Bluetooth issues after resume from hibernation
+- Marks boot state as good after successful resume
+- User-configurable hibernation delay
+
+Configuration
+-------------
+
+To configure the hibernate delay and swap file size:
+
+1. Create the configuration directory:
+   mkdir -p /home/deck/.config
+
+2. Copy the example configuration:
+   cp /usr/share/doc/steamos-extension-hibernate-after-sleep/example-config \
+      /home/deck/.config/hibernate-after-sleep
+
+3. Edit the configuration file:
+   nano /home/deck/.config/hibernate-after-sleep
+
+4. Set your desired values:
+   - HibernateDelaySec (default: 60min)
+   - TargetSwapFileSizeInGbs (default: 20)
+
+5. Rerun the install script to apply changes:
+   sudo /usr/sbin/steamos-extension-hibernate-after-sleep-install
+
+Valid time values
+-----------------
+
+The HibernateDelaySec parameter accepts systemd time span values:
+- Seconds: "30s", "120s"
+- Minutes: "5min", "30min", "60min"
+- Hours: "1h", "2h"
+- Combinations: "1h 30min"
+
+What this extension does
+------------------------
+
+1. Creates a swap file at /home/swapfile (default: 20GB, configurable)
+2. Configures GRUB to resume from the swap file
+3. Sets up systemd-logind to bypass hibernation memory checks
+4. Enables suspend-then-hibernate behavior
+5. Configures the delay before hibernating (default: 60 minutes)
+6. Sets up services to fix Bluetooth and mark boot state after resume
+
+GRUB Changes
+------------
+
+This extension modifies the GRUB configuration directly to add resume parameters:
+- resume=/dev/disk/by-uuid/[UUID]
+- resume_offset=[OFFSET]
+
+After installation, your system will automatically hibernate after the
+configured delay when suspended.
+
+Troubleshooting
+---------------
+
+If hibernation doesn't work:
+
+1. Check that the swap file exists:
+   ls -lh /home/swapfile
+
+2. Verify GRUB configuration:
+   cat /boot/efi/EFI/steamos/grub.cfg | grep resume
+
+3. Check systemd sleep configuration:
+   cat /etc/systemd/sleep.conf
+
+4. Rerun the install script with --force flag:
+   sudo /usr/sbin/steamos-extension-hibernate-after-sleep-install --force
+
+5. Reboot the system
+
+Notes
+-----
+
+- The swap file defaults to 20GB (configurable via TargetSwapFileSizeInGbs)
+- Changes to GRUB or swap file size require a reboot to take effect
+- The extension will preserve existing resume parameters if they match
+- Bluetooth may briefly disconnect after resume (automatically fixed)

--- a/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/example-config
+++ b/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/example-config
@@ -1,0 +1,13 @@
+# Example configuration file for hibernate-after-sleep extension
+# Copy this file to: /home/deck/.config/hibernate-after-sleep
+#
+# HibernateDelaySec: Time to wait before hibernating after suspend
+# Valid values: time spans like "60s", "5min", "1h", etc.
+# Default: 60min
+
+HibernateDelaySec=60min
+
+# Examples:
+# HibernateDelaySec=30min  # Hibernate after 30 minutes of suspend
+# HibernateDelaySec=2h     # Hibernate after 2 hours of suspend
+# HibernateDelaySec=15min  # Hibernate after 15 minutes of suspend

--- a/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/steamos-extension-hibernate-after-sleep-uninstall.sh
+++ b/steamos-extension-hibernate-after-sleep/usr/share/doc/steamos-extension-hibernate-after-sleep/steamos-extension-hibernate-after-sleep-uninstall.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+set -e
+
+if [[ $EUID -ne 0 ]]; then
+	echo "This script must be run as root"
+	exit 1
+fi
+
+echo "==========================================="
+echo "Hibernate After Sleep - Uninstall Script"
+echo "==========================================="
+echo ""
+echo "This will:"
+echo "  - Remove suspend-then-hibernate configuration"
+echo "  - Remove systemd sleep configuration"
+echo "  - Remove systemd-logind hibernation bypass"
+echo "  - Remove GRUB resume parameters"
+echo "  - Optionally resize swapfile to 1GB"
+echo "  - Remove the extension"
+echo ""
+read -p "Continue? [y/N] " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+	echo "Aborted."
+	exit 0
+fi
+
+echo ""
+echo "Step 1: Removing and disabling hibernate-after-sleep service, helpers, and suspend link..."
+systemctl disable --now steamos-extension-hibernate-after-sleep-install.service
+systemctl disable --now steamos-extension-hibernate-after-sleep-fix-bluetooth.service
+systemctl disable --now steamos-extension-hibernate-after-sleep-mark-boot-good.service
+
+echo "Removing suspend link..."
+if [[ -L "/etc/systemd/system/steamos-extension-hibernate-after-sleep-install.service" ]]; then
+    rm -f /etc/systemd/system/systemd-suspend.service
+	echo "  Removed"
+else
+	echo "  Not found (skipping)"
+fi
+
+
+echo ""
+echo "Step 2: Removing sleep configuration..."
+if [[ -f "/etc/systemd/sleep.conf" ]]; then
+	rm -f /etc/systemd/sleep.conf
+	echo "  Removed"
+else
+	echo "  Not found (skipping)"
+fi
+
+echo ""
+echo "Step 3: Removing systemd-logind hibernation bypass..."
+override_file="/etc/systemd/system/systemd-logind.service.d/override.conf"
+if [[ -f "$override_file" ]]; then
+	if grep -q "SYSTEMD_BYPASS_HIBERNATION_MEMORY_CHECK" "$override_file"; then
+		temp_file=$(mktemp)
+		in_service_section=0
+
+		while IFS= read -r line; do
+			if [[ "$line" =~ ^\[Service\] ]]; then
+				in_service_section=1
+				echo "$line" >> "$temp_file"
+			elif [[ "$line" =~ ^\[.*\] ]]; then
+				in_service_section=0
+				echo "$line" >> "$temp_file"
+			elif [[ $in_service_section -eq 1 ]] && [[ "$line" =~ ^Environment=SYSTEMD_BYPASS_HIBERNATION_MEMORY_CHECK ]]; then
+				: # Skip this line
+			else
+				echo "$line" >> "$temp_file"
+			fi
+		done < "$override_file"
+
+		if [[ -s "$temp_file" ]] && grep -q "[^[:space:]]" "$temp_file"; then
+			mv "$temp_file" "$override_file"
+			echo "  Removed hibernation bypass (preserved other settings)"
+		else
+			rm -f "$override_file"
+			rmdir /etc/systemd/system/systemd-logind.service.d 2>/dev/null || true
+			rm -f "$temp_file"
+			echo "  Removed override file (was empty)"
+		fi
+	else
+		echo "  Bypass not found in override file (skipping)"
+	fi
+else
+	echo "  Override file not found (skipping)"
+fi
+
+echo ""
+echo "Step 4: Removing GRUB resume parameters..."
+starter=steamenv_boot
+cfg=/boot/efi/EFI/steamos/grub.cfg
+remount=false
+
+# HoloISO
+if [[ -f /boot/grub/grub.cfg ]]; then
+	starter=linux
+	cfg=/boot/grub/grub.cfg
+	remount=true
+fi
+
+if [[ ! -e $cfg ]]; then
+	echo "  Warning: GRUB config file not found at $cfg (skipping)"
+elif grep -q "resume=/dev/disk/by-uuid" "$cfg"; then
+	# HoloISO keeps boot on the readonly partition.
+	if $remount; then
+		steamos-readonly disable
+	fi
+
+	sed -i -E 's/ resume=[^ ]*//g' "$cfg"
+	sed -i -E 's/ resume_offset=[0-9]*//g' "$cfg"
+
+	if $remount; then
+		steamos-readonly enable
+	fi
+
+	echo "  Removed from GRUB (will take effect on next boot)"
+else
+	echo "  Not found in GRUB (skipping)"
+fi
+
+echo ""
+echo "Step 5: Swapfile management..."
+function is_btrfs {
+	local fstype=$(findmnt -no FSTYPE -T /home)
+	[[ "$fstype" == "btrfs" ]]
+}
+
+if is_btrfs; then
+	swapfile_path="/home/@swapfile/swapfile"
+else
+	swapfile_path="/home/swapfile"
+fi
+
+if [[ -f "$swapfile_path" ]]; then
+	current_size=$(stat -c %s "$swapfile_path" 2>/dev/null || echo 0)
+	current_size_gb=$((current_size / 1073741824))
+
+	echo "  Current swapfile: $swapfile_path (${current_size_gb}GB)"
+	echo ""
+	read -p "  Resize swapfile to 1GB? [y/N] " -n 1 -r
+	echo
+
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		echo "  Resizing swapfile to 1GB..."
+		swapoff "$swapfile_path" 2>/dev/null || true
+
+		if is_btrfs; then
+			rm -f "$swapfile_path"
+			truncate -s 0 "$swapfile_path"
+			chattr +C "$swapfile_path"
+			fallocate -l 1G "$swapfile_path"
+			chmod 600 "$swapfile_path"
+			mkswap "$swapfile_path"
+			swapon "$swapfile_path"
+		else
+			dd if=/dev/zero of="$swapfile_path" bs=1G count=1
+			chmod 600 "$swapfile_path"
+			mkswap "$swapfile_path"
+			swapon "$swapfile_path"
+		fi
+
+		echo "  Swapfile resized to 1GB"
+	else
+		echo "  Swapfile kept at current size"
+		swapon "$swapfile_path" 2>/dev/null || true
+	fi
+else
+	echo "  Swapfile not found (skipping)"
+fi
+
+echo ""
+echo "Step 6: Reloading systemd..."
+systemctl daemon-reload
+echo "  Reloaded"
+
+echo ""
+echo "Step 7: Removing extension..."
+extension_file="/var/lib/extensions/steamos-extension-hibernate-after-sleep.raw"
+if [[ -f "$extension_file" ]]; then
+	rm -f "$extension_file"
+	echo "  Removed extension file"
+	systemd-sysext refresh
+	echo "  Extension unmerged"
+else
+	echo "  Extension file not found at $extension_file"
+fi
+
+echo ""
+read -p "Remove uninstall script? [y/N] " -n 1 -r
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+	
+    echo "Cleaning up uninstall script..."
+    if [[ -f "/home/deck/.bin/steamos-extension-hibernate-after-sleep-uninstall.sh" ]]; then
+        rm -f /home/deck/.bin/steamos-extension-hibernate-after-sleep-uninstall.sh
+        echo "  Removed uninstall script"
+    fi
+fi
+
+echo ""
+echo "==========================================="
+echo "Uninstall complete!"
+echo "==========================================="
+echo ""
+echo "Changes made:"
+echo "  - Removed hibernate-after-sleep extension"
+echo "  - Removed systemd configurations"
+echo "  - Removed GRUB resume parameters"
+echo ""
+echo "Please reboot for all changes to take effect."


### PR DESCRIPTION
I originally started just making a manual script for https://github.com/nazar256/publications/blob/main/guides/steam-deck-hibernation.md
This includes both the bluetooth and marking the boot good after resuming fixes (identified in [issues](https://github.com/nazar256/publications/issues/2) and I experienced it as well)

Then I wanted to persist the changes, so your repo / leveraging systemd-sysext was the obvious path forward.